### PR TITLE
Updating google analytics tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'UA-116053119-1');
+      gtag('config', 'G-XVVDNCT5RG');
     </script>
 	
     <style>


### PR DESCRIPTION
We are currently using the Parsl google analytics tag by mistake potentially poisoning the analytics data for both projects. This PR updates the google-analytics tag to a funcX specific one.